### PR TITLE
[fix]: prevent users from selecting incompatible renderers

### DIFF
--- a/src/views/Upload/UploadSteps/UploadStepsDetails/UploadStepsDetails.tsx
+++ b/src/views/Upload/UploadSteps/UploadStepsDetails/UploadStepsDetails.tsx
@@ -10,7 +10,7 @@ import { FormField } from 'components/atoms/FormField';
 import { TextArea } from 'components/atoms/TextArea';
 import { Modal } from 'components/molecules/Modal';
 import { CollectionsTable } from 'components/organisms/CollectionsTable';
-import { ASSETS, DEFAULT_ASSET_TOPICS, GATEWAYS, RENDERERS } from 'helpers/config';
+import { ASSETS, CONTENT_TYPES, DEFAULT_ASSET_TOPICS, GATEWAYS, RENDERERS } from 'helpers/config';
 import { RendererType, ValidationType } from 'helpers/types';
 import { formatRequiredField } from 'helpers/utils';
 import { useLanguageProvider } from 'providers/LanguageProvider';
@@ -201,6 +201,64 @@ export default function UploadStepsDetails() {
 		return { status: false, message: null };
 	}
 
+	function isRendererCompatibleWithFiles(rendererOption: any) {
+		if (!uploadReducer.data.contentList || uploadReducer.data.contentList.length === 0) {
+			return true;
+		}
+
+		const rendererContentType = rendererOption.contentType;
+
+		for (const file of uploadReducer.data.contentList) {
+			const fileType = file.file.type;
+
+			if (rendererOption.label === '3D' && !fileType.includes('gltf-binary') && !file.file.name.endsWith('.glb')) {
+				return false;
+			}
+
+			if (
+				rendererOption.label === 'Audio' &&
+				!fileType.includes('audio') &&
+				!file.file.name.match(/\.(mp3|wav|ogg|m4a)$/i)
+			) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	function getIncompatibilityReason(rendererOption: any) {
+		if (!uploadReducer.data.contentList || uploadReducer.data.contentList.length === 0) {
+			return null;
+		}
+
+		const incompatibleFiles = [];
+
+		for (const file of uploadReducer.data.contentList) {
+			const fileType = file.file.type;
+			const fileName = file.file.name;
+
+			if (rendererOption.label === '3D' && !fileType.includes('gltf-binary') && !fileName.endsWith('.glb')) {
+				incompatibleFiles.push(fileName);
+			}
+
+			if (rendererOption.label === 'Audio' && !fileType.includes('audio') && !fileName.match(/\.(mp3|wav|ogg|m4a)$/i)) {
+				incompatibleFiles.push(fileName);
+			}
+		}
+
+		if (incompatibleFiles.length > 0) {
+			const fileNames =
+				incompatibleFiles.length > 2
+					? `${incompatibleFiles.slice(0, 2).join(', ')} and ${incompatibleFiles.length - 2} more`
+					: incompatibleFiles.join(', ');
+
+			return `Incompatible with: ${fileNames}`;
+		}
+
+		return null;
+	}
+
 	return (
 		<>
 			<S.Wrapper>
@@ -297,15 +355,20 @@ export default function UploadStepsDetails() {
 						</S.RInfo>
 						<S.ROptionsWrapper>
 							{Object.keys(rendererOptions).map((id: string, index: number) => {
+								const isCompatible = isRendererCompatibleWithFiles(rendererOptions[id]);
+								const compatibilityReason = !isCompatible ? getIncompatibilityReason(rendererOptions[id]) : null;
+
 								return (
 									<S.ROption
 										key={index}
 										active={renderer?.label === rendererOptions[id].label}
-										disabled={false}
-										onClick={() => handleRendererChange(rendererOptions[id])}
+										disabled={!isCompatible}
+										onClick={() => isCompatible && handleRendererChange(rendererOptions[id])}
+										title={compatibilityReason || ''}
 									>
 										<span>{rendererOptions[id].label}</span>
 										<p>{rendererOptions[id].description}</p>
+										{!isCompatible && <S.RIncompatible>{compatibilityReason}</S.RIncompatible>}
 									</S.ROption>
 								);
 							})}

--- a/src/views/Upload/UploadSteps/UploadStepsDetails/styles.ts
+++ b/src/views/Upload/UploadSteps/UploadStepsDetails/styles.ts
@@ -215,6 +215,7 @@ export const ROption = styled.button<{ active: boolean; disabled: boolean }>`
 		${(props) => (props.active ? props.theme.colors.button.alt1.border : props.theme.colors.button.primary.border)};
 	border-radius: ${STYLING.dimensions.radius.primary};
 	padding: 15px;
+	position: relative;
 	&:hover {
 		background: ${(props) => props.theme.colors.button.alt1.active.background};
 		border: 1px solid ${(props) => props.theme.colors.button.alt1.active.border};
@@ -252,4 +253,15 @@ export const ROption = styled.button<{ active: boolean; disabled: boolean }>`
 			color: ${(props) => props.theme.colors.button.primary.disabled.color} !important;
 		}
 	}
+`;
+
+export const RIncompatible = styled.div`
+	margin-top: 7.5px;
+	padding: 5px 10px;
+	background-color: ${(props) => props.theme.colors.warning + '33'}; /* 20% opacity */
+	border-radius: ${STYLING.dimensions.radius.alt2};
+	font-size: ${(props) => props.theme.typography.size.xxSmall} !important;
+	font-weight: ${(props) => props.theme.typography.weight.medium} !important;
+	color: ${(props) => props.theme.colors.warning} !important;
+	text-align: left;
 `;


### PR DESCRIPTION
This PR introduces file type-aware filtering for renderer selection to improve the upload experience and reduce invalid asset submissions.

Solution now:
- Detects the file type on upload
- Filters available renderers to only those compatible with the uploaded file
- Prevents users from selecting mismatched renderers in the UI

Why this matters:
- Improves UX by reducing user error

Prevents invalid renderer–asset pairings

Minimizes broken assets on-chain and in the marketplace

Fixes (#62) https://github.com/orgs/permaweb/projects/5/views/1?pane=issue&itemId=93494724&issue=permaweb%7Cbazar-studio%7C62